### PR TITLE
Feat/lookup world filter 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "dev.slne.surf.deathmessages"
-version = "1.1.9"
+version = "1.1.10"
 
 dependencies {
     compileOnly("dev.slne.surf.settings:surf-settings-api:+")

--- a/docs/superpowers/plans/2026-07-29-lookup-world-filter.md
+++ b/docs/superpowers/plans/2026-07-29-lookup-world-filter.md
@@ -1,0 +1,457 @@
+# Death-Lookup Weltfilter — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/death lookup` zeigt ohne `--world` Tode aus allen Welten und mit `--world <name>` gezielt Tode einer beliebigen Welt, unabhängig davon, wo der ausführende Spieler steht.
+
+**Architecture:** `DeathLookupFilter.worldName: String` wird zu `world: World?`, wobei `null` "alle Welten" bedeutet. Der Weltfilter wandert aus dem In-Memory-Sequence-Filter in die SQL-Query, damit das 500-Zeilen-Limit von `findAll` nicht Treffer aus selten benutzten Welten verschluckt. `parseDeathFilters` löst `--world` case-insensitive auf und bricht bei unbekanntem Namen mit einer Spielermeldung ab.
+
+**Tech Stack:** Kotlin, Paper 1.21.x, CommandAPI 11.2.0, Exposed v1 R2DBC (geshadet unter `dev.slne.surf.database.libs.…`), Gradle Wrapper.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-lookup-world-filter-design.md`
+
+## Global Constraints
+
+- **Kein Test-Framework vorhanden.** Das Projekt hat kein `src/test`, keine Test-Dependency und keinen Test-Task. Dieser Plan folgt deshalb **nicht** dem üblichen TDD-Zyklus. Jede Task wird durch (a) einen erfolgreichen Compile und (b) einen exakt beschriebenen manuellen In-Game-Check verifiziert. Lege keine Test-Infrastruktur an — das ist nicht Teil dieses Auftrags.
+- **Build-Kommando:** `./gradlew build` im Projektroot. Auf Windows/PowerShell `.\gradlew.bat build`.
+- **Exposed ist geshadet.** Alle Exposed-Imports beginnen mit `dev.slne.surf.database.libs.org.jetbrains.exposed.v1.…`. Niemals `org.jetbrains.exposed.…` direkt importieren.
+- **`Op.TRUE` existiert in dieser Exposed-Version nicht.** Der `Op.Companion` hat nur `build` und `nullOp` (per javap gegen `surf-database-r2dbc-2.3.1-all.jar` verifiziert). Bedingte WHERE-Klauseln müssen über einen nullable `Op<Boolean>` gebaut werden, nicht über einen Always-True-Platzhalter.
+- **Commit-Stil:** Gitmoji-Prefix plus Conventional-Commit-Typ, wie in der Repo-History (`✨ feat(death): …`, `♻️ refactor(death): …`).
+- **Branch:** `feat/lookup-world-filter-` (aktuell ausgecheckt).
+
+---
+
+### Task 1: Weltfilter in die SQL-Query von `DeathRepository`
+
+Beide Query-Methoden bekommen einen optionalen `worldId`-Parameter. Durch den Default `null` ändert sich für bestehende Aufrufer nichts — diese Task ist für sich allein compilierbar und verhaltensneutral.
+
+**Files:**
+- Modify: `src/main/kotlin/dev/slne/surf/deathmessages/database/repository/DeathRepository.kt:35-43` (`findHistory`)
+- Modify: `src/main/kotlin/dev/slne/surf/deathmessages/database/repository/DeathRepository.kt:62-69` (`findAll`)
+
+**Interfaces:**
+- Consumes: nichts aus früheren Tasks.
+- Produces:
+  - `suspend fun findHistory(playerUuid: UUID, worldId: UUID? = null): List<Death>`
+  - `suspend fun findAll(worldId: UUID? = null, amount: Int = 500): List<Death>`
+
+  In beiden Fällen bedeutet `worldId == null` "keine Welt-Einschränkung".
+
+- [ ] **Step 1: Import für `and` ergänzen**
+
+In `DeathRepository.kt` neben den bestehenden Exposed-Core-Imports einfügen:
+
+```kotlin
+import dev.slne.surf.database.libs.org.jetbrains.exposed.v1.core.and
+```
+
+Der Import gehört alphabetisch vor `…v1.core.eq` (Zeile 7).
+
+- [ ] **Step 2: `findHistory` um den Weltfilter erweitern**
+
+Ersetze die bestehende `findHistory`-Funktion (Zeile 35-43) vollständig durch:
+
+```kotlin
+    suspend fun findHistory(playerUuid: UUID, worldId: UUID? = null): List<Death> =
+        suspendTransaction {
+            val playerCondition = DeathsTable.playerId eq playerUuid
+            val condition = if (worldId == null) {
+                playerCondition
+            } else {
+                playerCondition.and(DeathsTable.worldId eq worldId)
+            }
+
+            DeathsTable
+                .selectAll()
+                .where(condition)
+                .orderBy(DeathsTable.id, SortOrder.DESC)
+                .map { it.toDeath() }
+                .toList()
+        }
+```
+
+`Query` hat zwei `where`-Overloads: einen mit Lambda und einen, der direkt ein `Op<Boolean>` nimmt. Hier wird der zweite benutzt, weil die Bedingung vorher zusammengebaut wird.
+
+`and` wird bewusst mit Punktnotation (`playerCondition.and(...)`) statt infix aufgerufen — das funktioniert unabhängig davon, ob die Funktion infix deklariert ist.
+
+- [ ] **Step 3: `findAll` um den Weltfilter erweitern**
+
+Ersetze die bestehende `findAll`-Funktion (Zeile 62-69) vollständig durch:
+
+```kotlin
+    suspend fun findAll(worldId: UUID? = null, amount: Int = 500): List<Death> =
+        suspendTransaction {
+            val condition = worldId?.let { DeathsTable.worldId eq it }
+
+            DeathsTable.selectAll()
+                .let { query -> if (condition == null) query else query.where(condition) }
+                .orderBy(DeathsTable.diedAt to SortOrder.DESC)
+                .limit(amount)
+                .map { it.toDeath() }
+                .toList()
+        }
+```
+
+Das `let` statt eines `apply` ist Absicht: `Query.where` gibt die Query zurück, und diese Form ist unabhängig davon korrekt, ob `where` die Query mutiert oder eine neue liefert.
+
+Wichtig: `amount` bleibt der **zweite** Parameter. Bestehende Aufrufer rufen `findAll()` ohne Argumente auf, das bleibt gültig.
+
+- [ ] **Step 4: Compile prüfen**
+
+Run: `./gradlew build`
+Expected: `BUILD SUCCESSFUL`. Keine Verhaltensänderung — dieser Schritt prüft nur, dass die Exposed-API korrekt getroffen wurde.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/kotlin/dev/slne/surf/deathmessages/database/repository/DeathRepository.kt
+git commit -m "♻️ refactor(death): allow filtering death queries by world id"
+```
+
+---
+
+### Task 2: `DeathLookupFilter` auf optionale Welt umstellen
+
+Diese Task macht den Default "alle Welten". `--world` wird noch **nicht** gelesen — das ist Task 3. Filter-Datenklasse, Service und Parser müssen zusammen geändert werden, sonst compiliert nichts.
+
+**Files:**
+- Modify: `src/main/kotlin/dev/slne/surf/deathmessages/command/subcommand/LookupCommand.kt:188-205` (`DeathLookupFilter`)
+- Modify: `src/main/kotlin/dev/slne/surf/deathmessages/command/subcommand/LookupCommand.kt:176-185` (Rückgabe von `parseDeathFilters`)
+- Modify: `src/main/kotlin/dev/slne/surf/deathmessages/database/service/DeathLookupService.kt:9-33`
+
+**Interfaces:**
+- Consumes: `DeathRepository.findHistory(playerUuid, worldId)` und `DeathRepository.findAll(worldId, amount)` aus Task 1.
+- Produces:
+  - `DeathLookupFilter` mit dem Feld `val world: World?` **anstelle von** `val worldName: String`. Die Feldreihenfolge bleibt sonst unverändert, `world` steht an derselben Position wie vorher `worldName` (nach `centerZ`, vor `limit`).
+  - `DeathLookupFilter.empty(player: Player)` liefert `world = null`.
+
+- [ ] **Step 1: Import für `World` ergänzen**
+
+In `LookupCommand.kt` neben `import org.bukkit.entity.Player` (Zeile 23) einfügen:
+
+```kotlin
+import org.bukkit.World
+```
+
+`org.bukkit.World` gehört alphabetisch vor `org.bukkit.entity.Player`.
+
+- [ ] **Step 2: `DeathLookupFilter` umstellen**
+
+Ersetze die Datenklasse (Zeile 188-205) vollständig durch:
+
+```kotlin
+data class DeathLookupFilter(
+    val playerUuid: UUID?,
+    val after: OffsetDateTime?,
+    val radius: Double?,
+    val centerX: Double,
+    val centerY: Double,
+    val centerZ: Double,
+    val world: World?,
+    val limit: Int
+) {
+    companion object {
+        fun empty(player: Player) = DeathLookupFilter(
+            null, null, null,
+            player.location.x, player.location.y, player.location.z,
+            null, 50
+        )
+    }
+}
+```
+
+`world = null` bedeutet: keine Welt-Einschränkung, es wird über alle Welten gesucht.
+
+- [ ] **Step 3: Rückgabe von `parseDeathFilters` anpassen**
+
+Ersetze das `return DeathLookupFilter(...)` am Ende von `parseDeathFilters` (Zeile 176-185) durch:
+
+```kotlin
+    return DeathLookupFilter(
+        playerUuid = playerUuid,
+        after = after,
+        radius = radius,
+        centerX = player.location.x,
+        centerY = player.location.y,
+        centerZ = player.location.z,
+        world = if (radius != null) player.world else null,
+        limit = this["--limit"]?.toIntOrNull() ?: 50
+    )
+```
+
+`radius != null -> player.world`: Eine Umkreissuche bleibt an eine Welt gebunden, weil dieselben XYZ-Koordinaten in Overworld, Nether und End nichts miteinander zu tun haben und sonst alle als Treffer im selben Umkreis auftauchen würden. Ohne `--radius` wird nicht eingeschränkt.
+
+- [ ] **Step 4: `DeathLookupService` auf den SQL-Filter umstellen**
+
+Ersetze den Rumpf von `lookup` in `DeathLookupService.kt` (Zeile 9-33) vollständig durch:
+
+```kotlin
+    suspend fun lookup(filter: DeathLookupFilter): List<Death> {
+        val worldId = filter.world?.uid
+
+        val source = if (filter.playerUuid != null) {
+            DeathRepository.findHistory(filter.playerUuid, worldId)
+        } else {
+            DeathRepository.findAll(worldId)
+        }
+
+        return source
+            .asSequence()
+            .filter { filter.after == null || it.diedAt.isAfter(filter.after) }
+            .filter {
+                if (filter.radius == null) true
+                else {
+                    val loc = it.location
+                    val distanceSq = (loc.x - filter.centerX).pow(2) +
+                            (loc.y - filter.centerY).pow(2) +
+                            (loc.z - filter.centerZ).pow(2)
+                    distanceSq <= filter.radius.pow(2)
+                }
+            }
+            .sortedByDescending { it.diedAt }
+            .take(filter.limit)
+            .toList()
+    }
+```
+
+Der bisherige In-Memory-Vergleich `.filter { it.location.world.name == filter.worldName }` entfällt ersatzlos — die Einschränkung passiert jetzt in der Query. Das ist der Punkt der Änderung: `findAll` lädt nur 500 Zeilen, und ein nachgelagerter Filter würde Treffer aus einer selten benutzten Welt verschlucken, sobald 500 neuere Tode aus anderen Welten davorliegen.
+
+- [ ] **Step 5: Compile prüfen**
+
+Run: `./gradlew build`
+Expected: `BUILD SUCCESSFUL`.
+
+Falls der Compiler `worldName` noch irgendwo bemängelt: das Feld wird ausschließlich in diesen beiden Dateien benutzt (per Grep verifiziert), es gibt keine weiteren Call-Sites.
+
+- [ ] **Step 6: In-Game verifizieren**
+
+Plugin bauen, auf den Testserver deployen, dann:
+
+1. Sorge dafür, dass in mindestens zwei Welten Tode existieren (z. B. in Overworld und Nether je einmal sterben).
+2. Stelle dich in die Overworld.
+3. `/death lookup`
+
+Expected: Die Ergebnisliste enthält Einträge aus **beiden** Welten. Der Weltname steht in Klammern hinter den Koordinaten — der Row-Renderer gibt ihn bereits aus (`LookupCommand.kt:82`), daran ist nichts zu ändern.
+
+4. `/death lookup --radius 50`
+
+Expected: Nur Tode aus der Welt, in der du stehst.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/kotlin/dev/slne/surf/deathmessages/command/subcommand/LookupCommand.kt src/main/kotlin/dev/slne/surf/deathmessages/database/service/DeathLookupService.kt
+git commit -m "✨ feat(death): search deaths across all worlds by default"
+```
+
+---
+
+### Task 3: `--world` parsen und unbekannte Welten abweisen
+
+**Files:**
+- Modify: `src/main/kotlin/dev/slne/surf/deathmessages/command/subcommand/LookupCommand.kt:114-150` (Executor-Body)
+- Modify: `src/main/kotlin/dev/slne/surf/deathmessages/command/subcommand/LookupCommand.kt:155-186` (`parseDeathFilters`)
+
+**Interfaces:**
+- Consumes: `DeathLookupFilter` mit `world: World?` aus Task 2.
+- Produces:
+  - `private suspend fun Map<String, String>.parseDeathFilters(player: Player): DeathLookupFilter?` — Rückgabetyp ist jetzt **nullable**. `null` bedeutet: die Eingabe war ungültig, dem Spieler wurde bereits eine Fehlermeldung geschickt, der Aufrufer muss abbrechen.
+  - `private fun resolveWorld(name: String): World?`
+
+- [ ] **Step 1: Import für `server` ergänzen**
+
+In `LookupCommand.kt` bei den `dev.slne.surf.api`-Imports einfügen:
+
+```kotlin
+import dev.slne.surf.api.paper.extensions.server
+```
+
+Das ist dieselbe Extension, die `DeathRepository.kt:4` bereits benutzt.
+
+- [ ] **Step 2: `resolveWorld`-Helper anlegen**
+
+Direkt über `parseDeathFilters` (also vor Zeile 155, unter der `rangeRegex`-Deklaration) einfügen:
+
+```kotlin
+private fun resolveWorld(name: String): World? =
+    server.getWorld(name) ?: server.worlds.firstOrNull { it.name.equals(name, ignoreCase = true) }
+```
+
+Erst der exakte Treffer, dann der case-insensitive Fallback. Damit funktioniert sowohl `--world world_nether` als auch `--world WORLD_NETHER`.
+
+Es werden ausschließlich echte Bukkit-Weltnamen akzeptiert. Baue **keine** Aliase wie `nether` oder `end` ein — über `World.Environment` wären die mehrdeutig, sobald der Server mehrere Welten desselben Environments betreibt.
+
+- [ ] **Step 3: `--world` in `parseDeathFilters` auswerten**
+
+Ersetze `parseDeathFilters` vollständig (von der Signatur bis zur schließenden Klammer, Zeile 155-186) durch:
+
+```kotlin
+private suspend fun Map<String, String>.parseDeathFilters(player: Player): DeathLookupFilter? {
+    val playerUuid = this["--player"]?.let { PlayerLookupService.getUuid(it) }
+
+    val radius = (this["--radius"] ?: this["--range"])?.toDoubleOrNull()
+
+    val after = this["--time"]?.let { rangeStr ->
+        val match = rangeRegex.find(rangeStr.trim()) ?: return@let null
+        val (valueStr, unit) = match.destructured
+        val value = valueStr.toLongOrNull() ?: return@let null
+
+        val seconds = when (unit.lowercase()) {
+            "s" -> value
+            "m" -> value * 60
+            "h" -> value * 3600
+            "d" -> value * 86400
+            "w" -> value * 604800
+            else -> 0L
+        }
+        OffsetDateTime.now().minusSeconds(seconds)
+    }
+
+    val requestedWorld = this["--world"]
+    val world = when {
+        requestedWorld != null -> resolveWorld(requestedWorld) ?: run {
+            player.sendText {
+                appendErrorPrefix()
+                error("Die Welt ")
+                variableValue(requestedWorld)
+                error(" existiert nicht.")
+                appendNewline()
+                info("Verfügbare Welten: ")
+                variableValue(server.worlds.joinToString(", ") { it.name })
+            }
+            return null
+        }
+
+        radius != null -> player.world
+        else -> null
+    }
+
+    return DeathLookupFilter(
+        playerUuid = playerUuid,
+        after = after,
+        radius = radius,
+        centerX = player.location.x,
+        centerY = player.location.y,
+        centerZ = player.location.z,
+        world = world,
+        limit = this["--limit"]?.toIntOrNull() ?: 50
+    )
+}
+```
+
+Die Reihenfolge im `when` ist bedeutsam: ein explizites `--world` gewinnt immer, auch in Kombination mit `--radius`. `--world world_nether --radius 50` sucht also im Umkreis der eigenen Koordinaten, aber innerhalb des Nether.
+
+Der Abbruch läuft bewusst über `return null` plus Spielermeldung statt über einen CommandAPI-Exception-Throw: die Meldung soll optisch zum übrigen Command-Feedback passen, das durchgängig `appendErrorPrefix()` / `error()` benutzt (siehe `LookupCommand.kt:127-130`).
+
+Ein unbekannter Weltname bricht ab, statt still 0 Treffer zu liefern — sonst wäre ein Tippfehler nicht von "es gibt wirklich keine Tode" zu unterscheiden.
+
+- [ ] **Step 4: Executor an den nullable Rückgabewert anpassen**
+
+Ersetze in `playerExecutorSuspend` die Zeile
+
+```kotlin
+        val filter = query?.parseDeathFilters(player) ?: DeathLookupFilter.empty(player)
+```
+
+durch:
+
+```kotlin
+        val queryMap = query
+        val filter = if (queryMap == null) {
+            DeathLookupFilter.empty(player)
+        } else {
+            queryMap.parseDeathFilters(player) ?: return@playerExecutorSuspend
+        }
+```
+
+Zwei Gründe für diese Form:
+
+1. Der Elvis-Operator geht nicht mehr, weil `null` jetzt zwei verschiedene Dinge bedeuten könnte — "kein Query-Argument angegeben" und "Query war ungültig". Die müssen unterschiedlich behandelt werden.
+2. `query` ist eine **delegierte** Property (`val query: Map<String, String>? by args`). Auf delegierte Properties greift kein Smart-Cast, deshalb wird der Wert vorher in das lokale `queryMap` gelesen.
+
+- [ ] **Step 5: Compile prüfen**
+
+Run: `./gradlew build`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 6: In-Game verifizieren**
+
+Plugin bauen und deployen, dann in der **Overworld** stehend durchgehen:
+
+| Kommando | Erwartung |
+| --- | --- |
+| `/death lookup --world world_nether` | nur Nether-Tode, obwohl du in der Overworld stehst |
+| `/death lookup --world WORLD_NETHER` | identisches Ergebnis (case-insensitive) |
+| `/death lookup --world quatsch` | Fehlermeldung „Die Welt quatsch existiert nicht." plus Liste der verfügbaren Welten, keine Ergebnisliste |
+| `/death lookup --world world_nether --radius 50` | Umkreissuche um deine Koordinaten, aber nur Nether-Treffer |
+| `/death lookup --player <name> --world world_nether` | nur Nether-Tode dieses Spielers |
+| `/death lookup` | weiterhin Tode aus allen Welten |
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/kotlin/dev/slne/surf/deathmessages/command/subcommand/LookupCommand.kt
+git commit -m "✨ feat(death): add --world filter to death lookup"
+```
+
+---
+
+### Task 4: Nebenfix — doppelte Flag-Werte erlauben
+
+Eigenständiger Bug, unabhängig vom Weltfilter, aber in derselben Zeile. Deshalb eigener Commit.
+
+**Files:**
+- Modify: `src/main/kotlin/dev/slne/surf/deathmessages/command/subcommand/LookupCommand.kt:110`
+
+**Interfaces:**
+- Consumes: nichts.
+- Produces: nichts. Reine Verhaltensänderung am Argument-Parser.
+
+- [ ] **Step 1: `withoutValueList` mit `allowDuplicates = true` aufrufen**
+
+Ersetze in der `optionalArgument`-Deklaration die Zeile
+
+```kotlin
+            .withoutValueList()
+```
+
+durch:
+
+```kotlin
+            .withoutValueList(true)
+```
+
+Hintergrund: `withoutValueList()` delegiert an `withValueList(null, false)` (`MapArgumentBuilder.java:171` → `:144`), wobei das `false` `allowValueDuplicates` ist. Beim Parsen landet jeder Wert in einem Set; ist er schon enthalten, bricht der Befehl mit `"Duplicate values are not allowed!"` ab (`MapArgument.java:289` → `:416`). Praktische Folge: `/death lookup --page 2 --limit 2` wird abgelehnt, weil beide Flags den Wert `2` tragen.
+
+Das `true` schaltet ausschließlich die Duplikatsprüfung für **Werte** ab. Doppelte **Keys** bleiben weiterhin verboten, was korrekt ist — eine Map kann `--page` nicht zweimal enthalten.
+
+- [ ] **Step 2: Compile prüfen**
+
+Run: `./gradlew build`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: In-Game verifizieren**
+
+| Kommando | Erwartung |
+| --- | --- |
+| `/death lookup --page 2 --limit 2` | wird angenommen, liefert Seite 2 mit Limit 2 — **vorher** roter Brigadier-Syntaxfehler |
+| `/death lookup --radius 50 --limit 50` | wird angenommen |
+| `/death lookup --page 1 --page 2` | wird weiterhin abgelehnt (doppelter Key) |
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/kotlin/dev/slne/surf/deathmessages/command/subcommand/LookupCommand.kt
+git commit -m "🐛 fix(death): allow duplicate flag values in lookup query"
+```
+
+---
+
+## Abschluss
+
+Nach Task 4 ist der Branch fertig. Führe die Verifikationstabellen aus Task 3 Step 6 und Task 4 Step 3 noch einmal am Stück durch, bevor du einen PR aufmachst — die späteren Tasks fassen dieselbe Datei an wie die früheren.
+
+Bewusst nicht Teil dieses Plans:
+
+- Tab-Completion für `--world`. `MapArgumentBuilder` kennt nur eine globale Value-List für alle Keys, und diese Liste wird erzwungen: jeder Wert, der nicht drinsteht, wird abgelehnt (`MapArgument.java:282`). Weltnamen dort einzutragen würde `--player` und `--limit` unbrauchbar machen. Discovery läuft über die Fehlermeldung aus Task 3.
+- Verschieben der übrigen Filter (`--time`, `--radius`, `--limit`) in die SQL-Query. Bestehendes Verhalten, außerhalb des Scopes.

--- a/docs/superpowers/specs/2026-07-29-lookup-world-filter-design.md
+++ b/docs/superpowers/specs/2026-07-29-lookup-world-filter-design.md
@@ -1,0 +1,122 @@
+# Death-Lookup: Weltfilter über `--world`
+
+**Datum:** 2026-07-29
+**Branch:** `feat/lookup-world-filter`
+
+## Problem
+
+`/death lookup` zeigt ausschließlich Tode aus der Welt, in der der ausführende
+Spieler gerade steht. Wer aus der Overworld einen Tod im Nether nachschlagen
+will, muss vorher in den Nether wechseln.
+
+Ursache: `parseDeathFilters` setzt `worldName` hart auf `player.world.name`
+(`LookupCommand.kt:183`), und `DeathLookupService.lookup` filtert bedingungslos
+darauf (`DeathLookupService.kt:18`). Der Key `--world` steht bereits in der
+Key-List des `MapArgument` (`LookupCommand.kt:109`), wird aber nirgends gelesen.
+
+## Ziel
+
+- Ohne `--world` werden Tode aus **allen** Welten angezeigt.
+- Mit `--world <name>` wird auf genau diese Welt eingeschränkt, unabhängig davon,
+  wo der ausführende Spieler steht.
+- `--radius` bleibt an genau eine Welt gebunden.
+
+## Design
+
+### Filter-Modell
+
+`DeathLookupFilter.worldName: String` wird zu `world: World?`.
+
+Ein Bukkit-`World` statt eines Strings, weil daraus sowohl `uid` (für den
+SQL-Filter) als auch `name` (für Meldungen) verfügbar ist. `null` bedeutet
+"alle Welten".
+
+`DeathLookupFilter.empty(player)` setzt `world = null`. Der Default ohne jegliche
+Flags ist damit serverweit.
+
+Die Center-Koordinaten (`centerX/Y/Z`) bleiben unverändert; sie sind ohnehin nur
+relevant, wenn `radius != null`.
+
+### Parsing (`parseDeathFilters`)
+
+| Eingabe                          | Ergebnis                                              |
+| -------------------------------- | ----------------------------------------------------- |
+| `--world <name>`                 | die Welt, case-insensitive gematcht                    |
+| kein `--world`, aber `--radius`  | `player.world` — Umkreissuche bleibt an eine Welt gebunden |
+| weder `--world` noch `--radius`  | `null` → alle Welten                                   |
+| `--world <unbekannt>`            | Fehlermeldung mit verfügbaren Welten, Suche bricht ab  |
+
+Auflösung des Weltnamens: `Bukkit.getWorld(name)`, bei `null` Fallback auf
+`server.worlds.firstOrNull { it.name.equals(name, ignoreCase = true) }`.
+
+**Warum `--radius` ohne `--world` die aktuelle Welt impliziert:** Eine
+Umkreissuche über Weltgrenzen hinweg ist inhaltlich sinnlos — dieselben
+XYZ-Koordinaten in Overworld, Nether und End haben nichts miteinander zu tun und
+würden als Treffer im selben Umkreis erscheinen.
+
+**Fehlerbehandlung:** `parseDeathFilters` bekommt einen nullable Rückgabewert.
+Die Funktion sendet die Fehlermeldung selbst über das im File etablierte
+`appendErrorPrefix()` / `error()`-Pattern; der Executor macht bei `null` ein
+`return@playerExecutorSuspend`. Bewusst kein CommandAPI-Exception-Throw — das
+würde optisch aus dem Rahmen des übrigen Command-Feedbacks fallen.
+
+Ein unbekannter Weltname bricht ab, statt still 0 Treffer zu liefern: sonst ist
+ein Tippfehler nicht von "wirklich keine Tode" zu unterscheiden.
+
+### Repository: Weltfilter gehört in die Query
+
+`DeathRepository.findAll()` lädt die 500 neuesten Tode serverweit
+(`DeathRepository.kt:62`); erst danach filtert `DeathLookupService` in-memory auf
+die Welt. Bliebe das so, würde `--world nether` weiterhin "keine Tode gefunden"
+liefern, sobald 500 neuere Tode aus anderen Welten davorliegen — derselbe
+sichtbare Fehler wie bisher, nur mit anderer Ursache. Der Weltfilter muss deshalb
+auf DB-Ebene greifen:
+
+- `findAll(worldId: UUID? = null, amount: Int = 500)` — optionales
+  `.where { DeathsTable.worldId eq worldId }`
+- `findHistory(playerUuid: UUID, worldId: UUID? = null)` analog
+- `DeathLookupService.lookup` reicht `filter.world?.uid` durch und lässt den
+  In-Memory-Weltvergleich ersatzlos fallen
+
+`DeathsTable.worldId` ist bereits eine eigene Spalte (`DeathsTable.kt:12`), es
+sind keine Schema-Änderungen nötig.
+
+### Anzeige
+
+Unverändert. Der Row-Renderer gibt den Weltnamen bereits pro Zeile aus
+(`spacer("(${record.location.world.name})")`, `LookupCommand.kt:82`),
+weltübergreifende Ergebnisse sind damit ohne Anpassung lesbar.
+
+## Betroffene Dateien
+
+- `command/subcommand/LookupCommand.kt`
+- `database/service/DeathLookupService.kt`
+- `database/repository/DeathRepository.kt`
+
+`DeathLookupFilter` wird außerhalb dieser Dateien nicht verwendet (per Grep
+verifiziert), es gibt also keine weiteren Call-Sites.
+
+## Verifikation
+
+Das Projekt hat kein Test-Verzeichnis (`src/test` existiert nicht) und keine
+Test-Infrastruktur. Verifikation erfolgt über:
+
+1. Gradle-Build (Compile) muss durchlaufen.
+2. Manueller Test im Spiel:
+   - `/death lookup` in der Overworld zeigt Tode aus Nether und End mit.
+   - `/death lookup --world world_nether` aus der Overworld heraus zeigt
+     Nether-Tode.
+   - `/death lookup --world WORLD_NETHER` funktioniert ebenfalls
+     (case-insensitive).
+   - `/death lookup --world quatsch` liefert die Fehlermeldung mit der
+     Weltenliste.
+   - `/death lookup --radius 50` beschränkt weiterhin auf die aktuelle Welt.
+   - `/death lookup --world world_nether --radius 50` sucht im Umkreis der
+     eigenen Koordinaten, aber innerhalb des Nether.
+
+## Bewusst nicht enthalten
+
+- Wert-Vorschläge (Tab-Completion) für `--world`: `MapArgumentBuilder`
+  unterstützt nur eine globale Value-List für alle Keys, nicht pro Key.
+- Verschieben der übrigen Filter (`--time`, `--radius`, `--limit`) in die
+  SQL-Query. Bestehendes Verhalten, außerhalb des Scopes dieser Änderung.

--- a/docs/superpowers/specs/2026-07-29-lookup-world-filter-design.md
+++ b/docs/superpowers/specs/2026-07-29-lookup-world-filter-design.md
@@ -49,6 +49,29 @@ relevant, wenn `radius != null`.
 Auflösung des Weltnamens: `Bukkit.getWorld(name)`, bei `null` Fallback auf
 `server.worlds.firstOrNull { it.name.equals(name, ignoreCase = true) }`.
 
+Es werden ausschließlich echte Bukkit-Weltnamen akzeptiert, keine Kurz-Aliase wie
+`nether` oder `end`. Ein Alias-Mapping über `World.Environment` wäre mehrdeutig,
+sobald der Server mehrere Welten desselben Environments betreibt.
+
+### Eingabe-Syntax
+
+`MapArgumentBuilder("query", ' ')` setzt den Delimiter (Key → Value) auf ein
+Leerzeichen; der Separator (Paar → Paar) ist per Default ebenfalls `" "`
+(`MapArgumentBuilder.java:34`). Daraus ergibt sich:
+
+```
+/death lookup --world world_nether
+/death lookup --player Timon --world world_nether --time 7d
+```
+
+Weltnamen mit Leerzeichen müssen gequotet oder escaped werden, weil Werte bis
+zum nächsten Leerzeichen gelesen werden (`MapArgument.java:358`):
+
+```
+/death lookup --world "meine welt"
+/death lookup --world meine\ welt
+```
+
 **Warum `--radius` ohne `--world` die aktuelle Welt impliziert:** Eine
 Umkreissuche über Weltgrenzen hinweg ist inhaltlich sinnlos — dieselben
 XYZ-Koordinaten in Overworld, Nether und End haben nichts miteinander zu tun und
@@ -80,6 +103,35 @@ auf DB-Ebene greifen:
 
 `DeathsTable.worldId` ist bereits eine eigene Spalte (`DeathsTable.kt:12`), es
 sind keine Schema-Änderungen nötig.
+
+### Mitgenommener Nebenfix: doppelte Flag-Werte
+
+`withoutValueList()` (`LookupCommand.kt:110`) delegiert an
+`withValueList(null, false)` (`MapArgumentBuilder.java:171` → `:144`), wobei das
+`false` `allowValueDuplicates` ist. Beim Parsen landet jeder Wert in einem Set;
+ist er bereits enthalten, bricht der Befehl mit `"Duplicate values are not
+allowed!"` ab (`MapArgument.java:289` → `:416`).
+
+Praktische Folge: zwei Flags dürfen nicht denselben Wert tragen. Betroffen sind
+vor allem die Zahlen-Flags, die sich denselben Wertebereich teilen:
+
+```
+/death lookup --page 2 --limit 2       -> abgelehnt
+/death lookup --radius 50 --limit 50   -> abgelehnt
+```
+
+Der Fehler entsteht in der Parse-Phase, also bevor der Command-Body läuft: der
+Spieler sieht einen Brigadier-Syntaxfehler statt einer Plugin-Meldung, und die
+Tab-Completion bricht an derselben Stelle ab (`MapArgument.java:100`).
+
+Fix: `withoutValueList(true)`. Das schaltet ausschließlich die Duplikatsprüfung
+für Werte ab; doppelte **Keys** bleiben weiterhin verboten, was korrekt ist —
+eine Map kann `--page` nicht zweimal enthalten.
+
+Der Bug besteht unabhängig vom Weltfilter und trifft `--world` praktisch nie
+(Weltnamen kollidieren kaum mit Zahlen oder Spielernamen). Er wird hier
+mitgenommen, weil er in derselben Zeile sitzt, die für `--world` ohnehin
+angefasst wird — als eigener Commit.
 
 ### Anzeige
 
@@ -113,10 +165,14 @@ Test-Infrastruktur. Verifikation erfolgt über:
    - `/death lookup --radius 50` beschränkt weiterhin auf die aktuelle Welt.
    - `/death lookup --world world_nether --radius 50` sucht im Umkreis der
      eigenen Koordinaten, aber innerhalb des Nether.
+   - `/death lookup --page 2 --limit 2` wird angenommen (Nebenfix).
 
 ## Bewusst nicht enthalten
 
 - Wert-Vorschläge (Tab-Completion) für `--world`: `MapArgumentBuilder`
-  unterstützt nur eine globale Value-List für alle Keys, nicht pro Key.
+  unterstützt nur eine globale Value-List für alle Keys, nicht pro Key — und
+  diese Liste wird erzwungen, jeder nicht enthaltene Wert wird abgelehnt
+  (`MapArgument.java:282`). Weltnamen dort einzutragen würde `--player` und
+  `--limit` unbrauchbar machen. Discovery läuft daher über die Fehlermeldung.
 - Verschieben der übrigen Filter (`--time`, `--radius`, `--limit`) in die
   SQL-Query. Bestehendes Verhalten, außerhalb des Scopes dieser Änderung.

--- a/src/main/kotlin/dev/slne/surf/deathmessages/command/subcommand/LookupCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/deathmessages/command/subcommand/LookupCommand.kt
@@ -12,6 +12,7 @@ import dev.slne.surf.api.core.messages.pagination.Pagination
 import dev.slne.surf.api.core.service.PlayerLookupService
 import dev.slne.surf.api.core.util.dateTimeFormatter
 import dev.slne.surf.api.paper.command.executors.playerExecutorSuspend
+import dev.slne.surf.api.paper.extensions.server
 import dev.slne.surf.deathmessages.command.sendDeathInfoMessage
 import dev.slne.surf.deathmessages.database.Death
 import dev.slne.surf.deathmessages.database.service.DeathLookupService
@@ -20,6 +21,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.format.TextDecoration
+import org.bukkit.World
 import org.bukkit.entity.Player
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -106,20 +108,25 @@ fun lookupCommand() = subcommand("lookup") {
         MapArgumentBuilder<String, String>("query", ' ')
             .withKeyMapper { it.lowercase() }
             .withValueMapper { it }
-            .withKeyList(listOf("--player", "--time", "--radius", "--page", "--limit"))
-            .withoutValueList()
+            .withKeyList(listOf("--player", "--time", "--radius", "--page", "--limit", "--world"))
+            .withoutValueList(true)
             .build()
     )
 
     playerExecutorSuspend { player, args ->
         val query: Map<String, String>? by args
 
+        val queryMap = query
+        val filter = if (queryMap == null) {
+            DeathLookupFilter.empty(player)
+        } else {
+            queryMap.parseDeathFilters(player) ?: return@playerExecutorSuspend
+        }
+        val page = queryMap?.get("--page")?.toIntOrNull() ?: 1
+
         player.sendText {
             info("Es wird nach Todes-Einträgen gesucht…")
         }
-
-        val filter = query?.parseDeathFilters(player) ?: DeathLookupFilter.empty(player)
-        val page = query?.get("--page")?.toIntOrNull() ?: 1
 
         val deaths = DeathLookupService.lookup(filter)
 
@@ -152,7 +159,10 @@ fun lookupCommand() = subcommand("lookup") {
 
 private val rangeRegex by lazy { Regex("""(\d+)([smhdw])""", RegexOption.IGNORE_CASE) }
 
-private suspend fun Map<String, String>.parseDeathFilters(player: Player): DeathLookupFilter {
+private fun resolveWorld(name: String): World? =
+    server.getWorld(name) ?: server.worlds.firstOrNull { it.name.equals(name, ignoreCase = true) }
+
+private suspend fun Map<String, String>.parseDeathFilters(player: Player): DeathLookupFilter? {
     val playerUuid = this["--player"]?.let { PlayerLookupService.getUuid(it) }
 
     val radius = (this["--radius"] ?: this["--range"])?.toDoubleOrNull()
@@ -173,6 +183,25 @@ private suspend fun Map<String, String>.parseDeathFilters(player: Player): Death
         OffsetDateTime.now().minusSeconds(seconds)
     }
 
+    val requestedWorld = this["--world"]
+    val world = when {
+        requestedWorld != null -> resolveWorld(requestedWorld) ?: run {
+            player.sendText {
+                appendErrorPrefix()
+                error("Die Welt ")
+                variableValue(requestedWorld)
+                error(" existiert nicht.")
+                appendNewline()
+                info("Verfügbare Welten: ")
+                variableValue(server.worlds.joinToString(", ") { it.name })
+            }
+            return null
+        }
+
+        radius != null -> player.world
+        else -> null
+    }
+
     return DeathLookupFilter(
         playerUuid = playerUuid,
         after = after,
@@ -180,7 +209,7 @@ private suspend fun Map<String, String>.parseDeathFilters(player: Player): Death
         centerX = player.location.x,
         centerY = player.location.y,
         centerZ = player.location.z,
-        worldName = player.world.name,
+        world = world,
         limit = this["--limit"]?.toIntOrNull() ?: 50
     )
 }
@@ -192,14 +221,14 @@ data class DeathLookupFilter(
     val centerX: Double,
     val centerY: Double,
     val centerZ: Double,
-    val worldName: String,
+    val world: World?,
     val limit: Int
 ) {
     companion object {
         fun empty(player: Player) = DeathLookupFilter(
             null, null, null,
             player.location.x, player.location.y, player.location.z,
-            player.world.name, 50
+            null, 50
         )
     }
 }

--- a/src/main/kotlin/dev/slne/surf/deathmessages/database/repository/DeathRepository.kt
+++ b/src/main/kotlin/dev/slne/surf/deathmessages/database/repository/DeathRepository.kt
@@ -4,6 +4,7 @@ import dev.slne.surf.api.core.util.logger
 import dev.slne.surf.api.paper.extensions.server
 import dev.slne.surf.database.libs.org.jetbrains.exposed.v1.core.ResultRow
 import dev.slne.surf.database.libs.org.jetbrains.exposed.v1.core.SortOrder
+import dev.slne.surf.database.libs.org.jetbrains.exposed.v1.core.and
 import dev.slne.surf.database.libs.org.jetbrains.exposed.v1.core.eq
 import dev.slne.surf.database.libs.org.jetbrains.exposed.v1.core.statements.api.ExposedBlob
 import dev.slne.surf.database.libs.org.jetbrains.exposed.v1.r2dbc.deleteWhere
@@ -32,11 +33,18 @@ object DeathRepository {
                 ?.toDeath()
         }
 
-    suspend fun findHistory(playerUuid: UUID): List<Death> =
+    suspend fun findHistory(playerUuid: UUID, worldId: UUID? = null): List<Death> =
         suspendTransaction {
+            val playerCondition = DeathsTable.playerId eq playerUuid
+            val condition = if (worldId == null) {
+                playerCondition
+            } else {
+                playerCondition.and(DeathsTable.worldId eq worldId)
+            }
+
             DeathsTable
                 .selectAll()
-                .where { DeathsTable.playerId eq playerUuid }
+                .where(condition)
                 .orderBy(DeathsTable.id, SortOrder.DESC)
                 .map { it.toDeath() }
                 .toList()
@@ -59,9 +67,12 @@ object DeathRepository {
             DeathsTable.deleteWhere { DeathsTable.deathId eq deathUuid }
         }
 
-    suspend fun findAll(amount: Int = 500): List<Death> =
+    suspend fun findAll(worldId: UUID? = null, amount: Int = 500): List<Death> =
         suspendTransaction {
+            val condition = worldId?.let { DeathsTable.worldId eq it }
+
             DeathsTable.selectAll()
+                .let { query -> if (condition == null) query else query.where(condition) }
                 .orderBy(DeathsTable.diedAt to SortOrder.DESC)
                 .limit(amount)
                 .map { it.toDeath() }

--- a/src/main/kotlin/dev/slne/surf/deathmessages/database/service/DeathLookupService.kt
+++ b/src/main/kotlin/dev/slne/surf/deathmessages/database/service/DeathLookupService.kt
@@ -7,15 +7,16 @@ import kotlin.math.pow
 
 object DeathLookupService {
     suspend fun lookup(filter: DeathLookupFilter): List<Death> {
+        val worldId = filter.world?.uid
+
         val source = if (filter.playerUuid != null) {
-            DeathRepository.findHistory(filter.playerUuid)
+            DeathRepository.findHistory(filter.playerUuid, worldId)
         } else {
-            DeathRepository.findAll()
+            DeathRepository.findAll(worldId)
         }
 
         return source
             .asSequence()
-            .filter { it.location.world.name == filter.worldName }
             .filter { filter.after == null || it.diedAt.isAfter(filter.after) }
             .filter {
                 if (filter.radius == null) true


### PR DESCRIPTION
This pull request implements a flexible world filter for the `/death lookup` command, allowing users to specify the world to search in via the `--world` flag, or to search across all worlds if the flag is omitted. The filter is now applied at the database query level, ensuring accurate and efficient results. Additionally, a bug with duplicate flag values is fixed, allowing the same value to be used for different flags. The main changes are grouped below:

**World Filter Redesign and Query Logic:**

* Replaced the world filter in `DeathLookupFilter` from a `String` to a nullable `World` object, with `null` meaning "all worlds". The filter is now resolved from the `--world` flag, or, if not given but `--radius` is set, defaults to the player's current world. [[1]](diffhunk://#diff-34a5b25bd2d2eb0c8ffc6fcf5b40dffddc0dda1e6933944831ab4115c5b3751dR186-R212) [[2]](diffhunk://#diff-34a5b25bd2d2eb0c8ffc6fcf5b40dffddc0dda1e6933944831ab4115c5b3751dL195-R231)
* The world filter is now applied directly in the database queries: `DeathRepository.findAll` and `findHistory` accept an optional `worldId` and use it for filtering, instead of filtering in-memory after loading results. [[1]](diffhunk://#diff-e98b8474feb665b1d3239ce77df53f475489e85f99e55cac2fecc764a8da1bb5L35-R47) [[2]](diffhunk://#diff-e98b8474feb665b1d3239ce77df53f475489e85f99e55cac2fecc764a8da1bb5L62-R75)
* The `/death lookup` command uses the improved filter logic, and error handling for unknown world names now provides a helpful message listing all available worlds. [[1]](diffhunk://#diff-34a5b25bd2d2eb0c8ffc6fcf5b40dffddc0dda1e6933944831ab4115c5b3751dL109-L123) [[2]](diffhunk://#diff-34a5b25bd2d2eb0c8ffc6fcf5b40dffddc0dda1e6933944831ab4115c5b3751dL155-R165) [[3]](diffhunk://#diff-34a5b25bd2d2eb0c8ffc6fcf5b40dffddc0dda1e6933944831ab4115c5b3751dR186-R212)

**Bugfixes and Input Handling:**

* Fixed a bug where duplicate values for different flags (e.g., `--page 2 --limit 2`) were incorrectly rejected. Now, only duplicate keys are disallowed, not duplicate values.
* Improved error handling for unknown world names: if a user specifies a world that does not exist, the command aborts with a clear error message and a list of valid worlds. [[1]](diffhunk://#diff-34a5b25bd2d2eb0c8ffc6fcf5b40dffddc0dda1e6933944831ab4115c5b3751dL155-R165) [[2]](diffhunk://#diff-34a5b25bd2d2eb0c8ffc6fcf5b40dffddc0dda1e6933944831ab4115c5b3751dR186-R212)

**Service Layer Updates:**

* `DeathLookupService.lookup` now passes the resolved world ID to the repository layer and removes redundant in-memory world filtering.

These changes make `/death lookup` more flexible, efficient, and user-friendly, and resolve several longstanding issues with world filtering and input validation.